### PR TITLE
♻️ Remove virtual modifier from example contracts

### DIFF
--- a/src/example/ExampleERC1155.sol
+++ b/src/example/ExampleERC1155.sol
@@ -41,7 +41,7 @@ abstract contract ExampleERC1155 is ERC1155, OperatorFilterer, Ownable {
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public virtual override onlyAllowedOperator(from) {
+    ) public override onlyAllowedOperator(from) {
         super.safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 }

--- a/src/example/ExampleERC721.sol
+++ b/src/example/ExampleERC721.sol
@@ -72,7 +72,7 @@ abstract contract ExampleERC721 is ERC721, OperatorFilterer, Ownable {
         operatorFilteringEnabled = value;
     }
 
-    function _operatorFilteringEnabled() internal view virtual override returns (bool) {
+    function _operatorFilteringEnabled() internal view override returns (bool) {
         return operatorFilteringEnabled;
     }
 }

--- a/src/example/ExampleERC721A.sol
+++ b/src/example/ExampleERC721A.sol
@@ -72,7 +72,7 @@ abstract contract ExampleERC721A is ERC721A, OperatorFilterer, Ownable {
         operatorFilteringEnabled = value;
     }
 
-    function _operatorFilteringEnabled() internal view virtual override returns (bool) {
+    function _operatorFilteringEnabled() internal view override returns (bool) {
         return operatorFilteringEnabled;
     }
 }

--- a/src/example/upgradeable/ExampleERC1155Upgradeable.sol
+++ b/src/example/upgradeable/ExampleERC1155Upgradeable.sol
@@ -48,7 +48,7 @@ abstract contract ExampleERC1155Upgradeable is
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public virtual override onlyAllowedOperator(from) {
+    ) public override onlyAllowedOperator(from) {
         super.safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 }


### PR DESCRIPTION
## Description

Since these contracts are supposed to be example implementations, it doesn't make sense for some of the overridden functions to be marked as virtual.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
